### PR TITLE
Update Unet2d_pytorch.py

### DIFF
--- a/Unet2d_pytorch.py
+++ b/Unet2d_pytorch.py
@@ -52,7 +52,7 @@ class residualUnit(nn.Module):
 
     def forward(self, x):
         out1 = self.activation(self.bn1(self.conv1(x)))
-        out2 = self.activation(self.bn1(self.conv2(out1)))
+        out2 = self.activation(self.bn2(self.conv2(out1)))
         if self.in_size!=self.out_size:
             bridge = self.activation(self.bnX(self.convX(x)))
         output = torch.add(out2, bridge)


### PR DESCRIPTION
I think **conv2** output should go through **bn2** rather than **bn1**, since the original code defined **bn2** but never used it.😎